### PR TITLE
Fix comment URL to image resource

### DIFF
--- a/src/imageStorage.ts
+++ b/src/imageStorage.ts
@@ -113,6 +113,6 @@ export async function uploadImageToImagesBranch(params: UploadParams): Promise<s
 	});
 
 	// Return raw URL to the file
-	const rawUrl = `https://raw.githubusercontent.com/${owner}/${repo}/${encodeURIComponent(branchName)}/${pathInRepo}`;
+	const rawUrl = `https://raw.githubusercontent.com/${owner}/${repo}/refs/heads/${encodeURIComponent(branchName)}/${pathInRepo}`;
 	return rawUrl;
 }


### PR DESCRIPTION
Fix raw GitHub URL construction to correctly display images in PR comments.

---
<a href="https://cursor.com/background-agent?bcId=bc-da1ffb81-c434-42a5-96b7-ed4d5f45b54f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-da1ffb81-c434-42a5-96b7-ed4d5f45b54f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

